### PR TITLE
update for directories 0.6

### DIFF
--- a/catapult-daemon.opam
+++ b/catapult-daemon.opam
@@ -12,6 +12,7 @@ depends: [
   "odoc" {with-doc}
   "catapult" {= version}
   "catapult-sqlite" {= version}
+  "fpath"
   "zmq" {>= "5.0"}
   "logs" {>= "0.7"}
 ]

--- a/catapult-sqlite.opam
+++ b/catapult-sqlite.opam
@@ -10,7 +10,8 @@ bug-reports: "https://github.com/imandra-ai/catapult/issues"
 depends: [
   "dune" {>= "2.7"}
   "sqlite3" {>= "5.0"}
-  "directories"
+  "directories" {>= "0.6"}
+  "fpath"
   "catapult" {= version}
   "odoc" {with-doc}
   "ocaml" {>= "4.08"}

--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,8 @@
   (synopsis "Sqlite-based backend for Catapult tracing")
   (depends
     (sqlite3 (>= "5.0"))
-    directories
+    (directories (>= "0.6"))
+    fpath
     (catapult (= :version))
     (odoc :with-doc)
     (ocaml (>= "4.08"))))
@@ -45,5 +46,6 @@
     (odoc :with-doc)
     (catapult (= :version))
     (catapult-sqlite (= :version))
+    fpath
     (zmq (>= "5.0"))
     (logs (>= "0.7"))))

--- a/src/daemon/catapult_daemon.ml
+++ b/src/daemon/catapult_daemon.ml
@@ -150,18 +150,18 @@ end = struct
     let now = now_us () in
     Str_tbl.filter_map_inplace
       (fun trace_id db ->
-        let age = now -. Atomic.get db.last_write in
-        if age > close_after_us then (
-          Trace.message "db.gc" ~data:(fun () ->
+          let age = now -. Atomic.get db.last_write in
+          if age > close_after_us then (
+            Trace.message "db.gc" ~data:(fun () ->
               [
                 "trace_id", `String trace_id;
                 "age", `Int (int_of_float (age *. 1e-6));
               ]);
-          close_ self ~trace_id db;
-          (* collect *)
-          None
-        ) else
-          Some db)
+            close_ self ~trace_id db;
+            (* collect *)
+            None
+          ) else
+            Some db)
       self.dbs
 
   let create ~dir () : t =
@@ -260,10 +260,10 @@ let setup_logs ~debug () =
   Logs.set_reporter (Logs.format_reporter ());
   Logs.set_level ~all:true
     (Some
-       (if debug then
-         Logs.Debug
-       else
-         Logs.Info));
+        (if debug then
+            Logs.Debug
+          else
+            Logs.Info));
   let lock = Mutex.create () in
   Logs.set_reporter_mutex
     ~lock:(fun () -> Mutex.lock lock)
@@ -284,7 +284,7 @@ let () =
     @@
     match Dir.data_dir with
     | None -> "."
-    | Some d -> d
+    | Some d -> Fpath.to_string d
   in
   let addr = ref Endpoint_address.default in
   let set_addr s = addr := Endpoint_address.of_string_exn s in
@@ -303,9 +303,9 @@ let () =
 
   setup_logs ~debug:!debug ();
   Log.info (fun k ->
-      k "daemon: listen on: %s, store traces in directory: %s"
-        (Endpoint_address.to_string !addr)
-        !dir);
+    k "daemon: listen on: %s, store traces in directory: %s"
+      (Endpoint_address.to_string !addr)
+      !dir);
 
   let writer = Writer.create ~dir:!dir () in
   let server = Server.create ~writer ~addr:!addr () in

--- a/src/sqlite/bin/catapult_conv.ml
+++ b/src/sqlite/bin/catapult_conv.ml
@@ -39,6 +39,7 @@ let write_json ~files ~out () =
       else (
         match Dir.data_dir with
         | Some d ->
+          let d = Fpath.to_string d in
           let file_in_d = Filename.concat d file in
           if Sys.file_exists file_in_d then
             file_in_d
@@ -48,7 +49,7 @@ let write_json ~files ~out () =
               fail ()
             else
               Filename.concat d files.(Array.length files - 1)
-            (* last entry *)
+              (* last entry *)
           ) else
             fail ()
         | None -> fail ()
@@ -61,9 +62,9 @@ let write_json ~files ~out () =
     let db = Db.db_open ~mode:`NO_CREATE file in
     let@ () =
       Fun.protect ~finally:(fun () ->
-          while not (Db.db_close db) do
-            ()
-          done)
+        while not (Db.db_close db) do
+          ()
+        done)
     in
     Db.exec db "PRAGMA journal=delete;" |> check_db_;
 
@@ -150,6 +151,7 @@ let () =
     match Dir.data_dir with
     | None -> failwith "please provide at least one file"
     | Some d ->
+      let d = Fpath.to_string d in
       let files = list_dir d in
       Printf.printf "no file provided.\n";
       if files <> [] then (


### PR DESCRIPTION
Hi,

`directories` is now using `Fpath.t` instead of `string`.

Here I implemented the dumb version that simply use `Fpath.to_string` after every call to `directories`.

If you're interested in propagating `Fpath.t` everywhere, it should be easily doable in a follow-up PR.

Cheers,